### PR TITLE
Ensure, that actual length (not byte count) of password is checked

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-0": {

--- a/lib/PasswordPolicy/Rules/Size.php
+++ b/lib/PasswordPolicy/Rules/Size.php
@@ -10,7 +10,7 @@ class Size extends Base {
     }
 
     public function test($password) {
-        return $this->testConstraint(strlen($password), $password);
+        return $this->testConstraint(mb_strlen($password), $password);
     }
 
     public function toJavaScript() {


### PR DESCRIPTION
Right now the `strlen` function is used to check password length. This works fine, when password consists of english alphabet.

When Russian symbols are used in the password (use 3 bytes per 1 letter), then weaker password will pass the check. This PR uses `mb_strlen` function to solve that problem.
